### PR TITLE
Add GuardJs runtime validation library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# GuardJs
+
+GuardJs is a simple runtime validation library. It exposes a `Guard` object that helps enforce preconditions and validate inputs at runtime. By failing fast when values are missing, invalid or out of range, GuardJs helps you catch bugs early and write more maintainable code.
+
+## Installation
+
+```bash
+npm install guardjs
+```
+
+## Usage
+
+```javascript
+import Guard from 'guardjs';
+
+function createUser(username, age) {
+    Guard.Against.NullOrWhiteSpace(username, 'username');
+    Guard.Against.OutOfRange(age, [18, 99], 'age');
+}
+
+function withdrawFunds(account, amount) {
+    Guard.Against.Null(account, 'account');
+    Guard.Against.NegativeOrZero(amount, 'amount');
+    Guard.Against.Expression(
+        account.balance,
+        balance => balance >= amount,
+        'Insufficient funds',
+        'balance'
+    );
+}
+
+async function registerUser(email) {
+    Guard.Against.NullOrWhiteSpace(email, 'email');
+    await Guard.Against.ExpressionAsync(
+        email,
+        async val => !(await isEmailTaken(val)),
+        'Email is already taken',
+        'email'
+    );
+}
+
+function processItems(items) {
+    Guard.Against.EmptyArray(items, 'items');
+    items.forEach(item => {
+        Guard.Against.UndefinedOrNullOrNaN(item.price, 'item.price');
+    });
+}
+
+function updateSettings(settings) {
+    Guard.Against.NotObject(settings, 'settings');
+    Guard.Against.EmptyObject(settings, 'settings');
+}
+
+function bookFlight(user, destination, seats) {
+    Guard.Against.Null(user, 'user');
+    Guard.Against.NullOrWhiteSpace(destination, 'destination');
+    Guard.Against.NegativeOrZero(seats, 'seats');
+}
+
+function sendNotification(userId) {
+    Guard.Against.Falsy(userId, 'userId');
+}
+```
+
+Use GuardJs at every trust boundary—any place you receive data from outside your immediate logic.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,96 @@
+const Guard = {
+    Against: {
+        NullOrUndefined(input, parameterName = 'Value', message = `cannot be null or undefined.`) {
+            if (input === null || input === undefined) {
+                throw new Error(`${parameterName} ${message}`);
+            }
+        },
+
+        Null(input, parameterName = 'Value', message = `cannot be null`) {
+            if (input === null) {
+                throw new Error(`${parameterName} ${message}`);
+            }
+        },
+
+        NullOrEmpty(input, parameterName = 'Value') {
+            this.Null(input, parameterName);
+            if (input.length === 0) {
+                throw new Error(`${parameterName} cannot be empty.`);
+            }
+        },
+
+        NullOrWhiteSpace(input, parameterName = 'Value') {
+            this.NullOrEmpty(input, parameterName);
+            if (typeof input === 'string' && input.trim().length === 0) {
+                throw new Error(`${parameterName} cannot be whitespace.`);
+            }
+        },
+
+        OutOfRange(input, range, parameterName = 'Value') {
+            this.Null(input, parameterName);
+            const [min, max] = range;
+            if (input < min || input > max) {
+                throw new Error(`${parameterName} is out of range. Must be between ${min} and ${max}.`);
+            }
+        },
+
+        Zero(input, parameterName = 'Value') {
+            if (input === 0) {
+                throw new Error(`${parameterName} cannot be zero.`);
+            }
+        },
+
+        Expression(input, func, message, paramName = 'Value') {
+            if (!func(input)) {
+                throw new Error(`${message}. Parameter: ${paramName}`);
+            }
+            return input;
+        },
+
+        async ExpressionAsync(input, func, message, paramName = 'Value') {
+            if (!await func(input)) {
+                throw new Error(`${message}. Parameter: ${paramName}`);
+            }
+            return input;
+        },
+
+        EmptyObject(input, parameterName = 'Value') {
+            if (Object.keys(input).length === 0) {
+                throw new Error(`${parameterName} cannot be an empty object.`);
+            }
+        },
+
+        UndefinedOrNullOrNaN(input, parameterName = 'Value') {
+            if (input === undefined || input === null || Number.isNaN(input)) {
+                throw new Error(`${parameterName} cannot be undefined, null, or NaN.`);
+            }
+        },
+
+        Falsy(input, parameterName = 'Value') {
+            if (!input) {
+                throw new Error(`${parameterName} cannot be falsy.`);
+            }
+        },
+
+        EmptyArray(input, parameterName = 'Value') {
+            if (Array.isArray(input) && input.length === 0) {
+                throw new Error(`${parameterName} cannot be an empty array.`);
+            }
+        },
+
+        NotObject(input, parameterName = 'Value') {
+            if (typeof input !== 'object' || input === null) {
+                throw new TypeError(`${parameterName} must be an object.`);
+            }
+        },
+
+        NegativeOrZero(input, parameterName = 'Value') {
+            if (input <= 0) {
+                throw new Error(`${parameterName} must be greater than zero.`);
+            }
+        }
+
+    }
+};
+
+export default Guard;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "guardjs",
+  "version": "0.1.0",
+  "description": "Runtime guard utility for validating inputs and enforcing preconditions.",
+  "main": "index.js",
+  "type": "module",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add Guard utility implementation
- document usage in README
- provide NPM metadata in package.json
- ignore node_modules for development

## Testing
- `node -e "import('./index.js').then(m=>console.log(Object.keys(m.default)))"`
- `npm pack`

------
https://chatgpt.com/codex/tasks/task_e_686cf033c77c83269f164b72be061af8