### PR TITLE
Add more guard examples and expand test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ function bookFlight(user, destination, seats) {
 function sendNotification(userId) {
     Guard.Against.Falsy(userId, 'userId');
 }
+
+function createOrder(order) {
+    Guard.Against.NotObject(order, 'order');
+    Guard.Against.EmptyObject(order, 'order');
+    Guard.Against.Zero(order.total, 'order.total');
+}
+
+function parseConfig(config) {
+    Guard.Against.NullOrUndefined(config.path, 'config.path');
+    Guard.Against.Falsy(config.enabled, 'config.enabled');
+}
+
+function sanitizeInput(str) {
+    Guard.Against.NullOrEmpty(str, 'str');
+    return str.trim();
+}
 ```
 
 Use GuardJs at every trust boundary—any place you receive data from outside your immediate logic.

--- a/tests/guard.test.js
+++ b/tests/guard.test.js
@@ -36,4 +36,48 @@ describe('Guard.Against', () => {
     expect(val).toBe(4);
     await expect(Guard.Against.ExpressionAsync(4, async v => v > 2, 'fail')).resolves.toBe(4);
   });
+
+  it('NullOrEmpty handles empty values', () => {
+    expect(() => Guard.Against.NullOrEmpty(null)).toThrow();
+    expect(() => Guard.Against.NullOrEmpty('')).toThrow();
+    expect(Guard.Against.NullOrEmpty('ok')).toBe('ok');
+  });
+
+  it('Zero throws when value is zero', () => {
+    expect(() => Guard.Against.Zero(0)).toThrow();
+    expect(Guard.Against.Zero(5)).toBe(5);
+  });
+
+  it('EmptyObject rejects empty objects', () => {
+    expect(() => Guard.Against.EmptyObject({})).toThrow();
+    const obj = { a: 1 };
+    expect(Guard.Against.EmptyObject(obj)).toBe(obj);
+  });
+
+  it('UndefinedOrNullOrNaN handles invalid values', () => {
+    expect(() => Guard.Against.UndefinedOrNullOrNaN(undefined)).toThrow();
+    expect(() => Guard.Against.UndefinedOrNullOrNaN(null)).toThrow();
+    expect(() => Guard.Against.UndefinedOrNullOrNaN(NaN)).toThrow();
+    expect(Guard.Against.UndefinedOrNullOrNaN(1)).toBe(1);
+  });
+
+  it('Falsy throws on falsy inputs', () => {
+    expect(() => Guard.Against.Falsy(0)).toThrow();
+    expect(() => Guard.Against.Falsy('')).toThrow();
+    expect(() => Guard.Against.Falsy(false)).toThrow();
+    expect(Guard.Against.Falsy(1)).toBe(1);
+  });
+
+  it('EmptyArray rejects an empty array', () => {
+    expect(() => Guard.Against.EmptyArray([])).toThrow();
+    const arr = [1];
+    expect(Guard.Against.EmptyArray(arr)).toBe(arr);
+  });
+
+  it('NotObject validates objects only', () => {
+    expect(() => Guard.Against.NotObject(null)).toThrow();
+    expect(() => Guard.Against.NotObject(5)).toThrow();
+    const obj = { b: 2 };
+    expect(Guard.Against.NotObject(obj)).toBe(obj);
+  });
 });


### PR DESCRIPTION
## Summary
- add additional usage examples demonstrating more guard checks
- greatly expand test coverage for the remaining guard helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d2b7db4c08326a8ddf8852b86b15e